### PR TITLE
Fixed pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,15 +2,20 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>net.dv8tion</groupId>
-  <artifactId>JDA</artifactId>
-  <version>3.0.0_188</version>
+  <groupId>com.gmail.accyrsed</groupId>
+  <artifactId>NovaBotJava</artifactId>
+  <version>1.0</version>
   <dependencies>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.5</version>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.dv8tion</groupId>
+      <artifactId>JDA</artifactId>
+      <version>3.0.0_188</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Due to mistake in projects pom.xml it currently is incorrectly indentified as **JDA** by github, breaking dependency graphs for over 8000+ projects.

Please, even if your no longer interested in this project, accept this pull request to patch this issue.